### PR TITLE
[#25] Fix the "Create event" is not visible on android phones

### DIFF
--- a/source/scripts/components/page/page.css
+++ b/source/scripts/components/page/page.css
@@ -6,7 +6,6 @@
 	bottom: 0;
 	display: flex;
 	flex-direction: column;
-	height: 100vh;
 }
 
 .header,


### PR DESCRIPTION
### Reason
The address bar shifted the button down
### Tested in
- Chrome in Android (65.0.3325.109)
- Chrome in Windows (65.0.3325.162)