### PR TITLE
Remove npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-# Mac
-.DS_Store


### PR DESCRIPTION
npmignore is only needed to publish npm packages